### PR TITLE
Add support for linux gnome

### DIFF
--- a/wallpaperChanger/exceptions.py
+++ b/wallpaperChanger/exceptions.py
@@ -1,0 +1,4 @@
+
+
+class PlatformNotSupportedException(Exception):
+    """Raised when the platform the script is running in is not supported"""

--- a/wallpaperChanger/mainScript.py
+++ b/wallpaperChanger/mainScript.py
@@ -13,7 +13,6 @@ You can run this script using a batch file and run it periodically (e.g., every 
 """
 
 # imports
-import ctypes
 import os
 import random
 import xml.etree.ElementTree as ET
@@ -22,6 +21,7 @@ from urllib.request import urlopen, Request
 import requests
 from PIL import Image, ImageFont, ImageDraw
 from wallpaperChanger.settings import ASSETS_DIR, GENERATED_DIR, OK_WALLPAPER, ERROR_WALLPAPER, API_KEY, CITY
+from wallpaperChanger import wallpaper
 
 pic_url = "https://www.theweather.com/wimages/foto9a654be7aab09bde5e0fd21539da5f0e.png"  # place custom weather
 # widget URL here <------- from https://www.theweather.com/
@@ -153,8 +153,7 @@ def getFailed():
         img1.text((3280, 2100), "by Clarence Yang", (255, 255, 255), font=font2)
         img.save(ERROR_WALLPAPER)
 
-    # Set failed wallpaper
-    ctypes.windll.user32.SystemParametersInfoW(20, 0, str(ERROR_WALLPAPER), 0)
+    wallpaper.set_wallpaper(ERROR_WALLPAPER)
 
 
 # returns current hour
@@ -211,7 +210,7 @@ def createWallpaper(daystate, WeatherCode):  # creates wallpaper: clean code?
 
     # save image and set it as the current wallpaper
     img.save(OK_WALLPAPER)
-    ctypes.windll.user32.SystemParametersInfoW(20, 0, str(OK_WALLPAPER), 0)
+    wallpaper.set_wallpaper(OK_WALLPAPER)
 
 
 if __name__ == '__main__':

--- a/wallpaperChanger/wallpaper.py
+++ b/wallpaperChanger/wallpaper.py
@@ -1,0 +1,35 @@
+import platform
+from pathlib import Path
+
+from wallpaperChanger.exceptions import PlatformNotSupportedException
+
+system = platform.system()  # https://docs.python.org/3/library/platform.html#platform.system
+
+# Used to identify is a system has support to change wallpaper
+# alternative to calling a method and catching the exception
+system_supported = True
+
+if system == 'Windows':
+    import ctypes
+
+
+    def set_wallpaper(file: Path):
+        """Change windows wallpaper to the provided file
+
+        :raises FileNotFoundError: if the provided file does not exist
+        """
+        if not file.exists() or not file.is_file():
+            raise FileNotFoundError(f"'{file}' was not found.")
+
+        ctypes.windll.user32.SystemParametersInfoW(20, 0, str(file), 0)
+
+elif system == 'Linux':
+    pass
+
+else:
+    system_supported = False
+
+
+    def set_wallpaper(file: Path):
+        """Dummy method that throws a PlatformNotSupportedException when called"""
+        raise PlatformNotSupportedException(f"'{system}' does not currently have support to change wallpaper.")

--- a/wallpaperChanger/wallpaper.py
+++ b/wallpaperChanger/wallpaper.py
@@ -1,9 +1,11 @@
 import platform
+import subprocess
 from pathlib import Path
 
 from wallpaperChanger.exceptions import PlatformNotSupportedException
 
-system = platform.system()  # https://docs.python.org/3/library/platform.html#platform.system
+# system = platform.system()  # https://docs.python.org/3/library/platform.html#platform.system
+system = ''
 
 # Used to identify is a system has support to change wallpaper
 # alternative to calling a method and catching the exception
@@ -24,12 +26,21 @@ if system == 'Windows':
         ctypes.windll.user32.SystemParametersInfoW(20, 0, str(file), 0)
 
 elif system == 'Linux':
-    pass
+    # TODO add support for kde desktops
+    def set_wallpaper(file: Path):
+        """Change linux wallpaper to the provided file
+
+        :raises FileNotFoundError: if the provided file does not exist
+        """
+        subprocess.Popen(
+            f"gsettings set org.gnome.desktop.background picture-uri 'file://{file}'",
+            shell=True,
+        )
 
 else:
     system_supported = False
 
 
     def set_wallpaper(file: Path):
-        """Dummy method that throws a PlatformNotSupportedException when called"""
+        """Placeholder function that throws a PlatformNotSupportedException when called"""
         raise PlatformNotSupportedException(f"'{system}' does not currently have support to change wallpaper.")

--- a/wallpaperChanger/wallpaper.py
+++ b/wallpaperChanger/wallpaper.py
@@ -1,6 +1,8 @@
 import platform
 import subprocess
+from functools import wraps
 from pathlib import Path
+from typing import Callable
 
 from wallpaperChanger.exceptions import PlatformNotSupportedException
 
@@ -10,23 +12,35 @@ system = platform.system()  # https://docs.python.org/3/library/platform.html#pl
 # alternative to calling a method and catching the exception
 system_supported = True
 
+
+def _ensure_exists(func: Callable[[Path], None]):
+    """Decorator that ensures that the file in the argument exists"""
+
+    @wraps(func)
+    def wrapper(file: Path):
+        if not file.exists() or not file.is_file():
+            raise FileNotFoundError(f"'{file}' was not found.")
+
+        return func(file)
+
+    return wrapper
+
+
 if system == 'Windows':
     import ctypes
 
-
+    @_ensure_exists
     def set_wallpaper(file: Path):
         """Change windows wallpaper to the provided file
 
         :raises FileNotFoundError: if the provided file does not exist
         """
-        if not file.exists() or not file.is_file():
-            raise FileNotFoundError(f"'{file}' was not found.")
-
         ctypes.windll.user32.SystemParametersInfoW(20, 0, str(file), 0)
 
 elif system == 'Linux':
 
     # TODO add support for kde desktops
+    @_ensure_exists
     def set_wallpaper(file: Path):
         """Change linux wallpaper to the provided file
 

--- a/wallpaperChanger/wallpaper.py
+++ b/wallpaperChanger/wallpaper.py
@@ -4,8 +4,7 @@ from pathlib import Path
 
 from wallpaperChanger.exceptions import PlatformNotSupportedException
 
-# system = platform.system()  # https://docs.python.org/3/library/platform.html#platform.system
-system = ''
+system = platform.system()  # https://docs.python.org/3/library/platform.html#platform.system
 
 # Used to identify is a system has support to change wallpaper
 # alternative to calling a method and catching the exception
@@ -26,6 +25,7 @@ if system == 'Windows':
         ctypes.windll.user32.SystemParametersInfoW(20, 0, str(file), 0)
 
 elif system == 'Linux':
+
     # TODO add support for kde desktops
     def set_wallpaper(file: Path):
         """Change linux wallpaper to the provided file


### PR DESCRIPTION
All wallpaper setting logic has been moved to `wallpaper.py`

Wallpaper can be changed using the `set_wallpaper(file)` function exposed. The function changes depending on the operating system, so other scripts dont need to be aware which platform the system is running on.

Usage is as simple as:

```
from pathlib import Path
from wallpaperChanger import wallpaper

wallpaper.set_wallpaper(Path('path/to/file'))
```

The function also checks if the specified file exists, if not found, raises FileNotFoundError